### PR TITLE
Fixed banner background positioning and sizing

### DIFF
--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -17,7 +17,8 @@ a {
 }
 .banner {
     background-image: url(../images/banner.png);
-    background-size: 100% 100%;
+    background-size: cover;
+    background-position: center;
     height: 40em;
     width: 100%;
     margin-top: 5%;


### PR DESCRIPTION
When viewing on devices with smaller screen size, the background image gets pretty badly sized, for this, just center the image and let the size be determined by the parent element.

**Before**
![image](https://cloud.githubusercontent.com/assets/5159834/24072548/e69ee56e-0c0e-11e7-9416-1b34b4f98d61.png)

**After**
![image](https://cloud.githubusercontent.com/assets/5159834/24072554/f4e34bf6-0c0e-11e7-8344-a16e206f7308.png)


